### PR TITLE
pulling out bbox fun and updating euro vax plot

### DIFF
--- a/R/lookups.R
+++ b/R/lookups.R
@@ -164,3 +164,21 @@ datasource_lk <- list(
   # Country population projections by age group
   un_age_projections = "https://population.un.org/wpp/Download/Files/1_Indicators%20(Standard)/CSV_FILES/WPP2019_PopulationBySingleAgeSex_2020-2100.csv"
 )
+
+#' @title Function to get bounding boxes for maps by WHO region
+#' @description Used internally in viz_maps.R functions for maps
+#' @returns a vector of class bbox (from the sf package)
+#'  with the min and max xy coordinates of the bounding box
+#' @keywords internal
+bbox_fun <- function(who_region, df) {
+
+  switch(who_region,
+         EURO = sf::st_bbox(c(xmin = -1400000, ymin = 200000, xmax = 6500000, ymax = 8200000)),
+         AMRO = sf::st_bbox(c(xmin = -14300000, ymin = -5500074, xmax = -3872374, ymax = 5000000)),
+         SEARO = sf::st_bbox(c(xmin = 6484395, ymin = -2008021, xmax = 12915540, ymax = 4596098)),
+         EMRO = sf::st_bbox(c(xmin = -1600000, ymin = -1800026.8, xmax = 6418436.7, ymax = 6245846.3)),
+         AFRO = sf::st_bbox(c(xmin = -2400000, ymin = -4200074, xmax = 6000000, ymax = 4218372)),
+         WPRO = sf::st_bbox(c(xmin = 5884395, ymin = -5308021, xmax = 16500000, ymax = 5396098)),
+         sf::st_bbox(sf::st_as_sf(df))
+  )
+}

--- a/R/viz_maps.R
+++ b/R/viz_maps.R
@@ -50,7 +50,7 @@ map_template <- function(df, category_color_labels = "None", category_color_valu
       legend.margin = ggplot2::margin(2, 2, 2, 2),
       legend.title = ggplot2::element_text(size = 8, family = "Calibri"),
       legend.text = ggplot2::element_text(size = 6, family = "Calibri"),
-      legend.background = element_rect(fill = "white", colour = "white")
+      legend.background = element_rect(fill = scales::alpha("white", 0.5), colour = "white")
       )
   } else {
     ggplot2::ggplot(df) + # Param
@@ -87,7 +87,7 @@ map_template <- function(df, category_color_labels = "None", category_color_valu
       legend.margin = ggplot2::margin(2, 2, 2, 2),
       legend.title = ggplot2::element_text(size = 8, family = "Calibri"),
       legend.text = ggplot2::element_text(size = 6, family = "Calibri"),
-      legend.background = element_rect(fill = "white", colour = "white")
+      legend.background = element_rect(fill = scales::alpha("white", 0.5), colour = "white")
     )
   }
 
@@ -256,7 +256,7 @@ map_vaccinations <- function(df, region = c("WHO Region", "State Region"), vac_t
     cat_vals <- c("#ccece6", "#afdacb", "#92c8b1", "#75b696", "#57a37c", "#3a9161", "#1d7f47", "#006d2c")
     map_template(df, cat_labs, cat_vals) +
       labs(
-        title = "People Who Completed Primary Vaccination \nSeries per 100 People",
+        title = "People Who Completed Primary Vaccination Series \nper 100 People",
         subtitle = paste0("Data as of ", format(max(df$date), "%B %d, %Y"), "\nRepresents percent of population who completed primary vaccination series"),
         caption = "Note:
        -Countries in white do not have data reported for completed primary vaccination series
@@ -268,8 +268,7 @@ map_vaccinations <- function(df, region = c("WHO Region", "State Region"), vac_t
       ggplot2::coord_sf(
         xlim = bbox[c(1, 3)],
         ylim = bbox[c(2, 4)]
-      ) +
-      theme(legend.background = element_rect(fill = scales::alpha("white", 0.5)))
+      )
   } else if (vac_type == "Booster") {
     cat_vals <- c("#DEC9E9", "#CCB6E0", "#BBA4D7", "#A991CE", "#977FC5", "#856CBC", "#745AB3", "#6247AA")
     map_template(df, cat_labs, cat_vals) +
@@ -302,16 +301,3 @@ map_vaccinations <- function(df, region = c("WHO Region", "State Region"), vac_t
   }
 }
 
-#' @keywords internal
-bbox_fun <- function(who_region, df) {
-
-  switch(who_region,
-               EURO = sf::st_bbox(c(xmin = -1400000, ymin = 1500000, xmax = 6500000, ymax = 8200000)),
-               AMRO = sf::st_bbox(c(xmin = -14300000, ymin = -5500074, xmax = -3872374, ymax = 5000000)),
-               SEARO = sf::st_bbox(c(xmin = 6484395, ymin = -2008021, xmax = 12915540, ymax = 4596098)),
-               EMRO = sf::st_bbox(c(xmin = -1600000, ymin = -1800026.8, xmax = 6418436.7, ymax = 6245846.3)),
-               AFRO = sf::st_bbox(c(xmin = -2400000, ymin = -4200074, xmax = 6000000, ymax = 4218372)),
-               WPRO = sf::st_bbox(c(xmin = 5884395, ymin = -5308021, xmax = 16500000, ymax = 5396098)),
-               sf::st_bbox(sf::st_as_sf(df))
-        )
-}

--- a/R/viz_maps.R
+++ b/R/viz_maps.R
@@ -128,7 +128,7 @@ map_burden <- function(df, region = c("WHO Region", "State Region")) {
   }
 
 
-  bbox <- bbox_fun(who_region)
+  bbox <- bbox_fun(who_region, df)
 
 
   subt <- paste0("Average daily incidence over the past 7 days per 100,000 population ", str_squish(format(max(df$date), "%B %e, %Y")))
@@ -180,7 +180,7 @@ map_trend <- function(df, region = c("WHO Region", "State Region")) {
     warning("Your dataframe has more than 1 date! This is a cross-sectional visualization!")
   }
 
-  bbox <- bbox_fun(who_region)
+  bbox <- bbox_fun(who_region, df)
 
   cat_labs <- c(">=50% decrease", "0 - <50% decrease", ">0 - <=50% increase", ">50 - <=100% increase", ">100 - <=200% increase", ">200% increase")
   cat_vals <- c("#1f9fa9", "#c0ebec", "#e57e51", "#d26230", "#c92929", "#7c0316")
@@ -230,7 +230,7 @@ map_vaccinations <- function(df, region = c("WHO Region", "State Region"), vac_t
     warning("Your dataframe has more than 1 date! This is a cross-sectional visualization!")
   }
 
-  bbox <- bbox_fun(who_region)
+  bbox <- bbox_fun(who_region, df)
 
   cat_labs <- c("<3", "3- <10", "10- <20", "20- <30", "30- <40", "40- <60", "60- <70", "70+")
 
@@ -303,7 +303,7 @@ map_vaccinations <- function(df, region = c("WHO Region", "State Region"), vac_t
 }
 
 #' @keywords internal
-bbox_fun <- function(who_region) {
+bbox_fun <- function(who_region, df) {
 
   switch(who_region,
                EURO = sf::st_bbox(c(xmin = -1400000, ymin = 1500000, xmax = 6500000, ymax = 8200000)),

--- a/R/viz_maps.R
+++ b/R/viz_maps.R
@@ -128,15 +128,7 @@ map_burden <- function(df, region = c("WHO Region", "State Region")) {
   }
 
 
-  bbox <- switch(who_region,
-    EURO = sf::st_bbox(c(xmin = -1400000, ymin = 1500000, xmax = 6500000, ymax = 9500000)),
-    AMRO = sf::st_bbox(c(xmin = -14300000, ymin = -5500074, xmax = -3872374, ymax = 5000000)),
-    SEARO = sf::st_bbox(c(xmin = 6484395, ymin = -2008021, xmax = 12915540, ymax = 4596098)),
-    EMRO = sf::st_bbox(c(xmin = -1600000, ymin = -1800026.8, xmax = 6418436.7, ymax = 6245846.3)),
-    AFRO = sf::st_bbox(c(xmin = -2400000, ymin = -4200074, xmax = 6000000, ymax = 4218372)),
-    WPRO = sf::st_bbox(c(xmin = 5884395, ymin = -5308021, xmax = 16500000, ymax = 5396098)),
-    sf::st_bbox(sf::st_as_sf(df))
-  )
+  bbox <- bbox_fun(who_region)
 
 
   subt <- paste0("Average daily incidence over the past 7 days per 100,000 population ", str_squish(format(max(df$date), "%B %e, %Y")))
@@ -188,15 +180,7 @@ map_trend <- function(df, region = c("WHO Region", "State Region")) {
     warning("Your dataframe has more than 1 date! This is a cross-sectional visualization!")
   }
 
-  bbox <- switch(who_region,
-    EURO = sf::st_bbox(c(xmin = -1400000, ymin = 1500000, xmax = 6500000, ymax = 9500000)),
-    AMRO = sf::st_bbox(c(xmin = -14300000, ymin = -5500074, xmax = -3872374, ymax = 5000000)),
-    SEARO = sf::st_bbox(c(xmin = 6484395, ymin = -2008021, xmax = 12915540, ymax = 4596098)),
-    EMRO = sf::st_bbox(c(xmin = -1600000, ymin = -1800026.8, xmax = 6418436.7, ymax = 6245846.3)),
-    AFRO = sf::st_bbox(c(xmin = -2400000, ymin = -4200074, xmax = 6000000, ymax = 4218372)),
-    WPRO = sf::st_bbox(c(xmin = 5884395, ymin = -5308021, xmax = 16500000, ymax = 5396098)),
-    sf::st_bbox(sf::st_as_sf(df))
-  )
+  bbox <- bbox_fun(who_region)
 
   cat_labs <- c(">=50% decrease", "0 - <50% decrease", ">0 - <=50% increase", ">50 - <=100% increase", ">100 - <=200% increase", ">200% increase")
   cat_vals <- c("#1f9fa9", "#c0ebec", "#e57e51", "#d26230", "#c92929", "#7c0316")
@@ -246,20 +230,13 @@ map_vaccinations <- function(df, region = c("WHO Region", "State Region"), vac_t
     warning("Your dataframe has more than 1 date! This is a cross-sectional visualization!")
   }
 
-  bbox <- switch(who_region,
-    EURO = sf::st_bbox(c(xmin = -1400000, ymin = 1500000, xmax = 6500000, ymax = 9500000)),
-    AMRO = sf::st_bbox(c(xmin = -14300000, ymin = -5500074, xmax = -3872374, ymax = 5000000)),
-    SEARO = sf::st_bbox(c(xmin = 6484395, ymin = -2008021, xmax = 12915540, ymax = 4596098)),
-    EMRO = sf::st_bbox(c(xmin = -1600000, ymin = -1800026.8, xmax = 6418436.7, ymax = 6245846.3)),
-    AFRO = sf::st_bbox(c(xmin = -2400000, ymin = -4200074, xmax = 6000000, ymax = 4218372)),
-    WPRO = sf::st_bbox(c(xmin = 5884395, ymin = -5308021, xmax = 16500000, ymax = 5396098)),
-    sf::st_bbox(sf::st_as_sf(df))
-  )
+  bbox <- bbox_fun(who_region)
 
   cat_labs <- c("<3", "3- <10", "10- <20", "20- <30", "30- <40", "40- <60", "60- <70", "70+")
 
   if (vac_type == "People") {
     cat_vals <- c("#b1eeec", "#98d1cf", "#7eb3b2", "#659695", "#4c7877", "#335b5a", "#193d3d", "#002020")
+
     map_template(df, cat_labs, cat_vals) +
       labs(
         title = "People Who Received at Least One Vaccine Dose per 100 People",
@@ -274,11 +251,12 @@ map_vaccinations <- function(df, region = c("WHO Region", "State Region"), vac_t
         xlim = bbox[c(1, 3)],
         ylim = bbox[c(2, 4)]
       )
+
   } else if (vac_type == "Fully") {
     cat_vals <- c("#ccece6", "#afdacb", "#92c8b1", "#75b696", "#57a37c", "#3a9161", "#1d7f47", "#006d2c")
     map_template(df, cat_labs, cat_vals) +
       labs(
-        title = "People Who Completed Primary Vaccination Series per 100 People",
+        title = "People Who Completed Primary Vaccination \nSeries per 100 People",
         subtitle = paste0("Data as of ", format(max(df$date), "%B %d, %Y"), "\nRepresents percent of population who completed primary vaccination series"),
         caption = "Note:
        -Countries in white do not have data reported for completed primary vaccination series
@@ -290,7 +268,8 @@ map_vaccinations <- function(df, region = c("WHO Region", "State Region"), vac_t
       ggplot2::coord_sf(
         xlim = bbox[c(1, 3)],
         ylim = bbox[c(2, 4)]
-      )
+      ) +
+      theme(legend.background = element_rect(fill = scales::alpha("white", 0.5)))
   } else if (vac_type == "Booster") {
     cat_vals <- c("#DEC9E9", "#CCB6E0", "#BBA4D7", "#A991CE", "#977FC5", "#856CBC", "#745AB3", "#6247AA")
     map_template(df, cat_labs, cat_vals) +
@@ -321,4 +300,18 @@ map_vaccinations <- function(df, region = c("WHO Region", "State Region"), vac_t
         ylim = bbox[c(2, 4)]
       )
   }
+}
+
+#' @keywords internal
+bbox_fun <- function(who_region) {
+
+  switch(who_region,
+               EURO = sf::st_bbox(c(xmin = -1400000, ymin = 1500000, xmax = 6500000, ymax = 8200000)),
+               AMRO = sf::st_bbox(c(xmin = -14300000, ymin = -5500074, xmax = -3872374, ymax = 5000000)),
+               SEARO = sf::st_bbox(c(xmin = 6484395, ymin = -2008021, xmax = 12915540, ymax = 4596098)),
+               EMRO = sf::st_bbox(c(xmin = -1600000, ymin = -1800026.8, xmax = 6418436.7, ymax = 6245846.3)),
+               AFRO = sf::st_bbox(c(xmin = -2400000, ymin = -4200074, xmax = 6000000, ymax = 4218372)),
+               WPRO = sf::st_bbox(c(xmin = 5884395, ymin = -5308021, xmax = 16500000, ymax = 5396098)),
+               sf::st_bbox(sf::st_as_sf(df))
+        )
 }


### PR DESCRIPTION
Hi Sean, 

Had a go at fixing a few things:

- wrapped text on 'fully' vaccination plot 
- pulled out the bbox code into a function (note did not document or test, just tagged as internal)
- for EURO: set ymax from 9500000 -> 820000
- also made background on legend transparent, this only really makes a difference for EURO, but only way I could think of doing without changing code to move legend.position depending on region (using scales::alpha, I think ok because scales is already a dependency)

For some reason, the fig looks a bit different than the other regions (no margins for some reason?)--not sure what's going on there.
![Screenshot 2022-05-10 175912](https://user-images.githubusercontent.com/42722106/167729444-f5dcefd7-27d7-4cb2-82cf-6bb80a53175a.png)

Not sure if I made it too much better, but atleast you can sort of see Portugal;)

