### PR TITLE
Fixing CI/CD error introduced by deprecation in gt v0.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Imports:
     ggplot2,
     flextable,
     ggrepel,
-    gt,
+    gt (>= 0.6.0),
     lubridate,
     officer,
     passport,

--- a/R/viz_tables.R
+++ b/R/viz_tables.R
@@ -172,7 +172,7 @@ table_10mostcases <- function(df, type = "Global", run_date = "Enter a date") {
       columns = c(value2),
       decimals = 1
     ) %>%
-        fmt_missing(
+    gt::sub_missing(
       columns = c(value1, value2),
       missing_text = "-"
     ) %>%
@@ -248,7 +248,7 @@ table_10incidence <- function(df, type = "Global", run_date = "Enter a date") {
       sep_mark = ",",
       decimals = 1
     ) %>%
-        fmt_missing(
+    gt::sub_missing(
       columns = c(value1, value2),
       missing_text = "-"
     ) %>%
@@ -328,7 +328,7 @@ table_10percentchange <- function(df, type = "Global", run_date = "Enter a date"
       value1 = gt::html("% Change<br>Last Week"),
       value2 = gt::html("% Change<br> 4 Weeks")
     ) %>%
-      fmt_missing(
+    gt::sub_missing(
       columns = c(value1, value2),
       missing_text = "-"
     ) %>%


### PR DESCRIPTION
- See rstudio/gt#912
- quoted columns not passed thru to sub_missing, throwing error in vignette production on CI pipeline
- Requiring gt >=0.6, fmt_missing -> sub_missing