### PR TITLE
HOTFIX: changing breaks for top-10 incidence table

### DIFF
--- a/R/viz_tables.R
+++ b/R/viz_tables.R
@@ -296,7 +296,7 @@ table_10incidence <- function(df, time_step = 7, region = NULL, data_as_of = NUL
       columns = c(ave_incidence),
       colors = scales::col_bin(
         palette = c("#f1e5a1", "#e7b351", "#d26230", "#aa001e"),
-        bins = c(0, 1, 10, 25, Inf),
+        bins = c(0, 1, 5, 10, Inf),
         na.color = "white"
       )
     ) %>%


### PR DESCRIPTION
## Changes
Apparently this wasn't updated earlier, but breaks should now match incidence map.

Ideally we make this dynamic in the long-term, but not a priority.

![image](https://github.com/CDCgov/SaviR/assets/25888380/33b01c55-f871-4caf-a234-75491fe1a32d)
